### PR TITLE
Better code highlighting

### DIFF
--- a/Encoder_with_PCINT.md
+++ b/Encoder_with_PCINT.md
@@ -7,7 +7,7 @@ currentValueLeft and currentValueRight are declared volatile byte.
 
 The encoders are on pins A0-A3 (PC0-PC3) on an atmega328p. Two LUT's are provided - they go in opposite directions; if it's going the wrong direction, comment out the one you're using and uncomment the other one. 
 
-```
+```c++
 //called from setup
 void setupPCINT() {
   PCMSK1 = 0x0F;

--- a/PROGMEM over 64KB.md
+++ b/PROGMEM over 64KB.md
@@ -1,9 +1,6 @@
 per https://forum.arduino.cc/index.php?topic=387506.0 post 10. 
 
-
-```
-
+```c++
 #define PROGMEM_LATE __attribute__ (( __section__(".fini1") ))
 const PROGMEM_LATE uint16_t data1[] = {big array};
-
 ```

--- a/PROGMEM_Arrays.md
+++ b/PROGMEM_Arrays.md
@@ -1,10 +1,9 @@
 ### Basic PROGMEM array
 
-```
+```c++
 const byte pgmArray[] PROGMEM={1,2,3,4,5}; 
 
 byte valueFromPROGMEM=pgm_read_byte_near(&pgmArray[2]); //remember the &
-
 ```
 
 
@@ -12,7 +11,7 @@ byte valueFromPROGMEM=pgm_read_byte_near(&pgmArray[2]); //remember the &
 
 Putting a bunch of strings into PROGMEM is a bit awkward - there's no one-line way to make the array - but works the same way. Almost all the functions to work with c strings have a _P (ex, snprintf_P() ) version that takes a pointer to PROGMEM string instead of a c string in RAM. 
 
-```
+```c++
 const char mode0L0[] PROGMEM="  RED  ";
 const char mode0L1[] PROGMEM=" GREEN ";
 const char mode0L2[] PROGMEM="  BLUE ";
@@ -26,17 +25,15 @@ const char * const modesL[][8] ={
 };
 ```
 
-To print, we can take advantage of __FlashStringHelper (which is used internally to make the F() macro work) to print these strings straight from PROGMEM: 
+To print, we can take advantage of `__FlashStringHelper` (which is used internally to make the F() macro work) to print these strings straight from PROGMEM:
 
 
-```
-
+```c++
 Serial.println(reinterpret_cast<const __FlashStringHelper *>(modesL[1][3])); //prints " WHITE "
 
 #define FLASH_STRING(flashptr) (reinterpret_cast<const __FlashStringHelper *>(flashptr))
 
 Serial.println(FLASH_STRING(modesL[1][3])); //same thing, but much cleaner using above macro
-
 ```
 
 
@@ -45,7 +42,7 @@ Serial.println(FLASH_STRING(modesL[1][3])); //same thing, but much cleaner using
 
 The above keeps the array of pointers to the PROGMEM strings in RAM. This still wastes 2 bytes of RAM per entry, though. We can keep the pointers in PROGMEM too to save that memory - but then we need to access them like something that's in progmem:
 
-```
+```c++
 const char mode0L0[] PROGMEM="  RED  ";
 const char mode0L1[] PROGMEM=" GREEN ";
 const char mode0L2[] PROGMEM="  BLUE ";
@@ -61,12 +58,10 @@ const char * const modesL[][8] PROGMEM ={
 
 Printing:
 
-```
-
+```c++
 Serial.println(reinterpret_cast<const __FlashStringHelper *>(pgm_read_word_near(&modesL[1][3]))); //prints " WHITE "
 
 #define FLASH_STRING(flashptr) (reinterpret_cast<const __FlashStringHelper *>(pgm_read_word_near(&flashptr)))
 
 Serial.println(FLASH_STRING(modesL[1][3])); //same thing, but much cleaner using above macro
-
 ```


### PR DESCRIPTION
GitHub does not apply syntax highlighting unless the language is specified at the opening of fenced code blocks. For example:

**before**:

```
//called from setup
void setupPCINT() {
  PCMSK1 = 0x0F;
  PCICR = 2;
}
```

**after**:

```c++
//called from setup
void setupPCINT() {
  PCMSK1 = 0x0F;
  PCICR = 2;
}
```